### PR TITLE
Enable v0.5 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-    #  - release
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
The tests should cover v0.5 (the current release)